### PR TITLE
Aviary and Owlery folders structure

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "platforms": {
     "Owlery": {
       "transformGroup": "scss",
-      "buildPath": "build/scss/",
+      "buildPath": "tokens/owlery/",
       "files": [
         {
           "destination": "colors.scss",
@@ -26,7 +26,7 @@
 
     "Aviary": {
       "transformGroup": "js",
-      "buildPath": "build/ts/",
+      "buildPath": "tokens/aviary/",
       "files": [
         {
           "format": "javascript/es6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "@ccayl/aviary-tokens",
+  "version": "0.0.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "description": "Testing 123",
   "main": "index.js",
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "build": "style-dictionary build"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Testing 123",
   "main": "index.js",
   "files": [
-    "index.js"
+    "tokens/*"
   ],
   "scripts": {
     "build": "style-dictionary build"

--- a/tokens/aviary/colors.ts
+++ b/tokens/aviary/colors.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 15 Jun 2022 15:44:11 GMT
+ * Generated on Wed, 15 Jun 2022 18:01:17 GMT
  */
 
 export const GlobalColorsGreen100 = "#FAFFFC";

--- a/tokens/aviary/colors.ts
+++ b/tokens/aviary/colors.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 15 Jun 2022 18:01:17 GMT
+ * Generated on Wed, 15 Jun 2022 18:03:04 GMT
  */
 
 export const GlobalColorsGreen100 = "#FAFFFC";

--- a/tokens/aviary/typography.ts
+++ b/tokens/aviary/typography.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 15 Jun 2022 15:44:11 GMT
+ * Generated on Wed, 15 Jun 2022 18:01:17 GMT
  */
 
 export const GlobalTypographyH1 = {"fontFamily":"Mulish","fontWeight":"700","lineHeight":"40","fontSize":"40","letterSpacing":"0%","paragraphSpacing":"0","textDecoration":"none","textCase":"none"};

--- a/tokens/aviary/typography.ts
+++ b/tokens/aviary/typography.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 15 Jun 2022 18:01:17 GMT
+ * Generated on Wed, 15 Jun 2022 18:03:04 GMT
  */
 
 export const GlobalTypographyH1 = {"fontFamily":"Mulish","fontWeight":"700","lineHeight":"40","fontSize":"40","letterSpacing":"0%","paragraphSpacing":"0","textDecoration":"none","textCase":"none"};

--- a/tokens/owlery/colors.scss
+++ b/tokens/owlery/colors.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 15 Jun 2022 18:01:17 GMT
+// Generated on Wed, 15 Jun 2022 18:03:04 GMT
 
 $global-colors-green-100: #FAFFFC;
 $global-colors-green-200: #EBF2EF;

--- a/tokens/owlery/colors.scss
+++ b/tokens/owlery/colors.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 15 Jun 2022 15:44:11 GMT
+// Generated on Wed, 15 Jun 2022 18:01:17 GMT
 
 $global-colors-green-100: #FAFFFC;
 $global-colors-green-200: #EBF2EF;

--- a/tokens/owlery/typography.scss
+++ b/tokens/owlery/typography.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 15 Jun 2022 15:44:11 GMT
+// Generated on Wed, 15 Jun 2022 18:01:17 GMT
 
 $global-typography-h1: [object Object];
 $global-typography-h2: [object Object];

--- a/tokens/owlery/typography.scss
+++ b/tokens/owlery/typography.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 15 Jun 2022 18:01:17 GMT
+// Generated on Wed, 15 Jun 2022 18:03:04 GMT
 
 $global-typography-h1: [object Object];
 $global-typography-h2: [object Object];


### PR DESCRIPTION
this removes the previous build folder and replaces it with this structure:

```
tokens
    owlery
        typography.scss
        colors.scss
    aviary
        typography.ts
        colors.ts
```

do we want this top level `tokens` folder? perhaps there is a way when we import this repo in hw-admin, its pointing directly to this tokens folder so we can do stuff like `{colors} from @aviary-tokens/aviary` ? if not - we can just have these `owlery` and `aviary` folder directly at the root