### PR TITLE
Adding in weights

### DIFF
--- a/build/scss/colors.scss
+++ b/build/scss/colors.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 29 Jun 2022 16:10:55 GMT
+// Generated on Mon, 04 Jul 2022 13:15:49 GMT
 
 $green100: #FAFFFC;
 $green200: #EBF2EF;

--- a/build/scss/typography.scss
+++ b/build/scss/typography.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 29 Jun 2022 16:10:55 GMT
+// Generated on Mon, 04 Jul 2022 13:15:49 GMT
 
 $letterSpacingbase: 0;
 $paragraphSpacingbase: 0;
@@ -84,3 +84,6 @@ $lineHeightsmall: 16px;
 $fontFamilysansSerif: Mulish;
 $weightheading: 700;
 $weightbase: 500;
+$weightlight: 400;
+$weightstrong: 600;
+$weightbold: 900;

--- a/build/ts/colors.ts
+++ b/build/ts/colors.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 29 Jun 2022 16:10:55 GMT
+ * Generated on Mon, 04 Jul 2022 13:15:49 GMT
  */
 
 export const green100 = "#FAFFFC";

--- a/build/ts/typography.ts
+++ b/build/ts/typography.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 29 Jun 2022 16:10:55 GMT
+ * Generated on Mon, 04 Jul 2022 13:15:49 GMT
  */
 
 export const letterSpacingbase = 0;
@@ -85,3 +85,6 @@ export const lineHeightsmall = "16px";
 export const fontFamilysansSerif = "Mulish";
 export const weightheading = 700;
 export const weightbase = 500;
+export const weightlight = 400;
+export const weightstrong = 600;
+export const weightbold = 900;

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -397,6 +397,18 @@
         "base": {
           "value": "500",
           "type": "fontWeights"
+        },
+        "light": {
+          "value": "400",
+          "type": "fontWeights"
+        },
+        "strong": {
+          "value": "600",
+          "type": "fontWeights"
+        },
+        "bold": {
+          "value": "900",
+          "type": "fontWeights"
         }
       }
     }

--- a/data/transformed-tokens.json
+++ b/data/transformed-tokens.json
@@ -564,6 +564,18 @@
       "base": {
         "value": 500,
         "type": "fontWeights"
+      },
+      "light": {
+        "value": 400,
+        "type": "fontWeights"
+      },
+      "strong": {
+        "value": 600,
+        "type": "fontWeights"
+      },
+      "bold": {
+        "value": 900,
+        "type": "fontWeights"
       }
     }
   }


### PR DESCRIPTION
We were missing values for our `light`, `strong`, and `bold` values in Typography weights