### PR TITLE
Adding in theme exports for Typescript typing

### DIFF
--- a/themes.d.ts
+++ b/themes.d.ts
@@ -1,3 +1,6 @@
 import * as light from "./build/ts/themes/light";
 
+type AviaryTheme = typeof light;
+
 export { light };
+export type { AviaryTheme };


### PR DESCRIPTION
This adds in Typing that can be used to cast the returned `theme` object in emotion! 

I basically just made it use the `typeof` the light theme to make things easy