### PR TITLE
Fix module exporting issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@fullscript/aviary-tokens",
-  "version": "0.0.1",
+  "version": "0.9.3",
   "description": "Testing 123",
   "main": "index.js",
   "files": [
     "index.js"
   ],
-  "type": "module",
   "scripts": {
     "build": "node build.js",
     "transform-core": "yarn token-transformer data transformed/transformed-core.json core --expandTypography",


### PR DESCRIPTION
I think this broke our package usage in hw-admin:

```
  "type": "module",
```

I think I’m remembering we actually can’t use the ES6 style standard due to…I think it was Enzyme/Jests fault? Ryan explained it to me when I was doing the initial adding of the package to hw-admin,  I’ll put up a PR to fix