### PR TITLE
colorProfileMapper object helper

### DIFF
--- a/helpers/colorProfileMapper.ts
+++ b/helpers/colorProfileMapper.ts
@@ -1,4 +1,4 @@
-import { AviaryTheme } from "../themes";
+import type { AviaryTheme } from "../themes";
 
 export const colorProfileMapper = (currentTheme: AviaryTheme) => {
   return {

--- a/helpers/colorProfileMapper.ts
+++ b/helpers/colorProfileMapper.ts
@@ -1,0 +1,11 @@
+import { AviaryTheme } from "../themes";
+
+export const colorProfileMapper = (currentTheme: AviaryTheme) => {
+  return {
+    primary: currentTheme.primary,
+    info: currentTheme.info,
+    warning: currentTheme.warning,
+    danger: currentTheme.danger,
+    highlight: currentTheme.highlight,
+  };
+};

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,0 +1,1 @@
+module.exports.colorProfileMapper = require("./colorProfileMapper");

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,1 +1,5 @@
-module.exports.colorProfileMapper = require("./colorProfileMapper");
+const colorProfileMapper = require("./colorProfileMapper");
+
+module.exports = {
+  colorProfileMapper,
+};


### PR DESCRIPTION
is this all we need?

everything should be nicely typed if we are passing in a `AviaryTheme` typed parameter - i don't see a need to make any other types for the time being? 

i omitted the `system` profile for now since i do not think it will 100% match our other profiles, and don't see it being needed for mapping.