### PR TITLE
Adding in Type support for standardized prop interfaces

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./interfaces";
+export * from "./profiles";

--- a/types/interfaces.ts
+++ b/types/interfaces.ts
@@ -1,0 +1,27 @@
+const AVIARY_COLORS = {
+  primary: "primary",
+  info: "info",
+  warning: "warning",
+  danger: "danger",
+  highlight: "highlight",
+};
+
+const EXTENDED_AVIARY_COLORS = {
+  ...AVIARY_COLORS,
+  system: "system",
+  light: "light"
+};
+
+type AviaryColors = keyof typeof AVIARY_COLORS;
+type ExtendedAviaryColors = keyof typeof EXTENDED_AVIARY_COLORS;
+
+interface AviaryColorProps {
+  isColor?: AviaryColors;
+}
+
+interface AviaryExtendedColorProps {
+  isColor?: ExtendedAviaryColors;
+}
+
+export type { AviaryColors, AviaryColorProps, AviaryExtendedColorProps, ExtendedAviaryColors };
+export { AVIARY_COLORS, EXTENDED_AVIARY_COLORS };

--- a/types/profiles.ts
+++ b/types/profiles.ts
@@ -1,0 +1,5 @@
+import * as light from "../build/ts/themes/light";
+
+type ColorProfileTheme = typeof light.primary;
+
+export type { ColorProfileTheme };


### PR DESCRIPTION
Adds in essentially what we already have within `hw-admin` for our shared interfaces, and also adds in the typing for individual profiles themselves (aka `primary`, and `info`)

Does all of these additions make sense?