### PR TITLE
fix: add typescript as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
   },
   "devDependencies": {
     "style-dictionary": "^3.7.0",
-    "token-transformer": "0.0.23"
-  },
-  "dependencies": {
+    "token-transformer": "0.0.23",
     "typescript": "^4.8.2"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
This MR adds Typescript as a dev dependency as suggested by Ryan here: https://git.fullscript.io/developers/hw-admin/-/merge_requests/38181#note_941269