### PR TITLE
Add prepack script and bump packageManager to yarn 4.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aviary-tokens",
   "license": "MIT",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Design tokens for the Fullscript Aviary design system",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "transform-dark": "yarn token-transformer src/data src/transformed/transformed-dark.json primitives,core-dark,themes/dark primitives,core-dark",
     "transform-emerson": "yarn token-transformer src/data src/transformed/transformed-emerson.json primitives,core-emerson,themes/emerson primitives,core-emerson",
     "transform-primitives": "yarn token-transformer src/data src/transformed/transformed-primitives.json primitives --expandTypography ",
-    "clean": "rm -rf dist/"
+    "clean": "rm -rf dist/",
+    "prepack": "yarn build"
   },
   "devDependencies": {
     "@babel/cli": "^7.27.2",
@@ -32,5 +33,5 @@
     "token-transformer": "0.0.23",
     "typescript": "^4.9.5"
   },
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "yarn@4.13.0"
 }


### PR DESCRIPTION
Yarn 4.13.0 passes configuration (including `npmMinimalAgeGate`) as environment variables when packing git-hosted dependencies. Older Yarn versions don't recognise these settings and fail with `YN0058`.

Additionally, added a `prepack` script. Without it, Yarn's git dependency pipeline skips the build entirely and the pack fails because the declared `main` entry point doesn't exist. Adding `"prepack": "yarn build"` ensures dependencies are installed and the build runs before packing.

Lemme know if this makes sense!

## Testing

- In a consuming project that uses Yarn 4.13.0 with `npmMinimalAgeGate` configured, update the git dependency reference to point at the new commit
- Bust your yarn cache with `yarn cache clean`
- Run `yarn install` and confirm the `YN0058` packing error doesn't happen
- Verify the package resolves and installs successfully